### PR TITLE
Stub indirect layer VI service functions

### DIFF
--- a/app/src/main/cpp/skyline/services/visrv/IApplicationDisplayService.cpp
+++ b/app/src/main/cpp/skyline/services/visrv/IApplicationDisplayService.cpp
@@ -124,4 +124,40 @@ namespace skyline::service::visrv {
 
         return {};
     }
+
+    Result IApplicationDisplayService::GetIndirectLayerImageMap(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        auto width{request.Pop<i64>()};
+        auto height{request.Pop<i64>()};
+
+        if (!request.outputBuf.empty()) {
+            // As we don't support indirect layers, we just fill the output buffer with red
+            auto imageBuffer{request.outputBuf.at(0)};
+            std::fill(imageBuffer.begin(), imageBuffer.end(), 0xFF0000FF);
+        }
+
+        response.Push<i64>(width);
+        response.Push<i64>(height);
+
+        return {};
+    }
+
+    Result IApplicationDisplayService::GetIndirectLayerImageRequiredMemoryInfo(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        i64 width{request.Pop<i64>()}, height{request.Pop<i64>()};
+
+        if (width <= 0 || height <= 0)
+            return result::InvalidDimensions;
+
+        constexpr size_t A8B8G8R8Size{4}; //!< The size of a pixel in the A8B8G8R8 format, this format is used by indirect layers
+        constexpr size_t AlignmentBytes{64}; //!< The alignment of the pitch and full buffer in bytes
+        u64 layerSize{static_cast<u64>(width) * static_cast<u64>(height) * A8B8G8R8Size};
+        u64 alignedLayerSize{util::AlignUp(layerSize, AlignmentBytes)};
+
+        constexpr size_t BlockSize{0x20000}; //!< The size of a block
+        constexpr size_t DefaultAlignment{0x1000}; //!< The default alignment of the buffer
+
+        response.Push<u64>((layerSize + BlockSize - 1) / (BlockSize * BlockSize)); // Calculate the number of blocks required to store the layer data
+        response.Push<u64>(DefaultAlignment);
+
+        return Result{};
+    }
 }

--- a/app/src/main/cpp/skyline/services/visrv/IApplicationDisplayService.h
+++ b/app/src/main/cpp/skyline/services/visrv/IApplicationDisplayService.h
@@ -89,6 +89,18 @@ namespace skyline::service::visrv {
         Result SetLayerScalingMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /**
+         * @brief Draws an indirect layer into the supplied buffer
+         * @url https://switchbrew.org/wiki/Display_services#GetIndirectLayerImageMap
+         */
+        Result GetIndirectLayerImageMap(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
+         * @brief Gets the amount of memory required for an indirect layer
+         * @url https://switchbrew.org/wiki/Display_services#GetIndirectLayerImageRequiredMemoryInfo
+         */
+        Result GetIndirectLayerImageRequiredMemoryInfo(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /**
          * @brief Converts an arbitrary scaling mode to a VI scaling mode
          */
         Result ConvertScalingMode(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
@@ -113,6 +125,8 @@ namespace skyline::service::visrv {
           SFUNC_BASE(0x7EF, IApplicationDisplayService, IDisplayService, DestroyStrayLayer),
           SFUNC(0x835, IApplicationDisplayService, SetLayerScalingMode),
           SFUNC(0x836, IApplicationDisplayService, ConvertScalingMode),
+          SFUNC(0x992, IApplicationDisplayService, GetIndirectLayerImageMap),
+          SFUNC(0x99C, IApplicationDisplayService, GetIndirectLayerImageRequiredMemoryInfo),
           SFUNC(0x1452, IApplicationDisplayService, GetDisplayVsyncEvent)
       )
     };

--- a/app/src/main/cpp/skyline/services/visrv/results.h
+++ b/app/src/main/cpp/skyline/services/visrv/results.h
@@ -7,5 +7,6 @@
 
 namespace skyline::service::visrv::result {
     constexpr Result InvalidArgument(114, 1);
+    constexpr Result InvalidDimensions(114, 4);
     constexpr Result IllegalOperation(114, 6);
 }


### PR DESCRIPTION
Indirect layers are used by the game to render layer on its own, the game allocates a buffer with the size from `GetIndirectLayerImageRequiredMemoryInfo` and uses `GetIndirectLayerImageMap` to draw the applet contents into the buffer. 

As we don't LLE applet implementations nor do our HLE implementations draw equivalent applets, we cannot submit this to the guest. As a result, these functions are stubbed with the framebuffer being cleared to red. 

Stubbing these functions allows titles such as Dark Souls to not crash while initializing indirect layers.