### PR TITLE
Add TIC format: 0x58D24946

### DIFF
--- a/app/src/main/cpp/skyline/gpu/interconnect/common/textures.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/common/textures.cpp
@@ -129,6 +129,8 @@ namespace skyline::gpu::interconnect {
             TIC_FORMAT_CASE_ST_SRGB(Astc10x8, Astc10x8, Unorm);
             TIC_FORMAT_CASE_ST(Astc10x10, Astc10x10, Unorm);
             TIC_FORMAT_CASE_ST_SRGB(Astc10x10, Astc10x10, Unorm);
+            TIC_FORMAT_CASE_ST(Astc12x12, Astc12x12, Unorm);
+	    TIC_FORMAT_CASE_ST_SRGB(Astc12x12, Astc12x12, Unorm);
             TIC_FORMAT_CASE_ST(BC2, BC2, Unorm);
             TIC_FORMAT_CASE_ST_SRGB(BC2, BC2, Unorm);
             TIC_FORMAT_CASE_ST(BC3, BC3, Unorm);

--- a/app/src/main/cpp/skyline/gpu/texture/format.h
+++ b/app/src/main/cpp/skyline/gpu/texture/format.h
@@ -158,6 +158,11 @@ namespace skyline::gpu::format {
                            .blockHeight = 10
     );
 
+    FORMAT_SUFF_UNORM_SRGB(Astc12x12, 128, eAstc12x12, Block,
+			   .blockWidth = 12,
+			   .blockHeight = 12
+    );
+
     // Depth/Stencil Formats
     // All of these have a G->R swizzle
     FORMAT(D16Unorm, 16, eD16Unorm, vka::eDepth, .swizzleMapping = {


### PR DESCRIPTION
Cult of the Lamb must be in-game and should fix some textures in Bayonetta 3

Co-authored-by: neogan-bot <neogan-bot@users.noreply.github.com>